### PR TITLE
Build provider for darwin_arm64 platform

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.12.1
+          go-version: 1.16.0
 
       - name: Build
         run: |

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Build
         run: |
           CGO_ENABLED=0 GOOS=darwin   GOARCH=amd64 go build -mod=vendor -ldflags="-s -w" -a -o build/terraform.octopus.com/terraform-provider-stripe/stripe/1.10.0/darwin_amd64/terraform-provider-stripe
+          CGO_ENABLED=0 GOOS=darwin   GOARCH=arm64 go build -mod=vendor -ldflags="-s -w" -a -o build/terraform.octopus.com/terraform-provider-stripe/stripe/1.10.0/darwin_arm64/terraform-provider-stripe
           CGO_ENABLED=0 GOOS=linux    GOARCH=386   go build -mod=vendor -ldflags="-s -w" -a -o build/terraform.octopus.com/terraform-provider-stripe/stripe/1.10.0/linux_386/terraform-provider-stripe
           CGO_ENABLED=0 GOOS=linux    GOARCH=amd64 go build -mod=vendor -ldflags="-s -w" -a -o build/terraform.octopus.com/terraform-provider-stripe/stripe/1.10.0/linux_amd64/terraform-provider-stripe
           CGO_ENABLED=0 GOOS=linux    GOARCH=arm   go build -mod=vendor -ldflags="-s -w" -a -o build/terraform.octopus.com/terraform-provider-stripe/stripe/1.10.0/linux_arm/terraform-provider-stripe

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ pkg/
 terraform.tf*
 crash.log
 terraform-provider-stripe
+
+# Mac OSX
+.DS_Store


### PR DESCRIPTION
Updated github action `build_release.yml` to build the provider for arm64 mac machines which involved updating the version of GO to 1.16 as that was the first version that supported darwin/arm64 https://go.dev/doc/go1.16#darwin 

also updated .gitignore to avoid that pesky .DS_STORE