### PR TITLE
Remove trailing whitespace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           .\build\upload-to-registry.ps1 -TerraformCloudApiKey "${{ secrets.TERRAFORM_CLOUD_API_KEY }}" `
                                          -TerraformCloudOrgName "${{ env.TerraformCloudOrgName }}" `
                                          -ProviderNamespace "${{ env.ProviderNamespace }}" `
-                                         -ProviderName "${{ env.ProviderName }}" `          
+                                         -ProviderName "${{ env.ProviderName }}" `
                                          -ProviderGpgKeyId "${{ secrets.TERRAFORM_CLOUD_STRIPE_PROVIDER_GPG_KEY_ID }}" `
                                          -ArtifactsJson '${{ steps.goreleaser.outputs.artifacts }}' `
                                          -MetadataJson '${{ steps.goreleaser.outputs.metadata }}'


### PR DESCRIPTION
Trailing whitespace after a backtick ` breaks the line continuation and was causing the run failure https://github.com/OctopusDeploy/terraform-provider-stripe/actions/runs/5284544667